### PR TITLE
Meeting Minutes Feature

### DIFF
--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -4,6 +4,7 @@ import {brewType} from './brew'
 import {eventType} from './event'
 import {galleryImageType} from './galleryImage'
 import {linkType} from './link'
+import {meetingMinutesType} from './meetingMinutes'
 import {memberType} from './member'
 import {postType} from './post'
 import {resourceType} from './resource'
@@ -39,6 +40,7 @@ export const schemaTypes: GroupDefinition<SchemaTypeDefinition>[] = [
   groupInto(linkType, resourceGroup),
   groupInto(resourceType, resourceGroup),
   galleryImageType,
+  meetingMinutesType,
   memberType,
   postType,
 ]

--- a/cms/schemaTypes/meetingMinutes.ts
+++ b/cms/schemaTypes/meetingMinutes.ts
@@ -1,0 +1,127 @@
+import {ComposeIcon as icon} from '@sanity/icons'
+import {format, parseISO} from 'date-fns'
+import {defineField, defineType} from 'sanity'
+
+import {memberType} from './member'
+import {required} from '../validations'
+
+/**
+ * This file is the schema definition for meeting minutes.
+ *
+ * Here you'll be able to edit the different fields that appear when you
+ * create or edit meeting minutes in the studio.
+ *
+ * Here you can see the different schema types that are available:
+
+  https://www.sanity.io/docs/schema-types
+
+ */
+
+export const meetingMinutesType = defineType({
+  name: 'meetingMinutes',
+  title: 'Meeting Minutes',
+  icon: icon,
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: required,
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96,
+        isUnique: (value, context) => context.defaultIsUnique(value, context),
+      },
+      validation: required,
+    }),
+    defineField({
+      name: 'meetingDate',
+      title: 'Meeting Date',
+      type: 'datetime',
+      initialValue: () => new Date().toISOString(),
+    }),
+    defineField({
+      name: 'author',
+      title: 'Author',
+      type: 'reference',
+      to: [{type: memberType.name}],
+    }),
+    defineField({
+      name: 'sharedTastings',
+      title: 'Shared Tastings',
+      type: 'array',
+      of: [
+        {type: 'block'},
+        {
+          type: 'image',
+          options: {
+            hotspot: true,
+          },
+          fields: [
+            {
+              name: 'caption',
+              type: 'string',
+              title: 'Image caption',
+              description: 'Caption displayed below the image.',
+            },
+            {
+              name: 'alt',
+              type: 'string',
+              title: 'Alternative text',
+              description: 'Important for SEO and accessiblity.',
+            },
+          ],
+        },
+      ],
+    }),
+    defineField({
+      name: 'meetingNotes',
+      title: 'Meeting Notes',
+      type: 'array',
+      of: [
+        {type: 'block'},
+        {
+          type: 'image',
+          options: {
+            hotspot: true,
+          },
+          fields: [
+            {
+              name: 'caption',
+              type: 'string',
+              title: 'Image caption',
+              description: 'Caption displayed below the image.',
+            },
+            {
+              name: 'alt',
+              type: 'string',
+              title: 'Alternative text',
+              description: 'Important for SEO and accessiblity.',
+            },
+          ],
+        },
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      author: 'author.name',
+      meetingDate: 'meetingDate',
+    },
+    prepare({title, author, meetingDate}) {
+      const subtitles = [
+        author && `by ${author}`,
+        meetingDate && `Meeting Date: ${format(parseISO(meetingDate), 'LLLd, yyyy')}`,
+      ].filter(Boolean)
+
+      return {title, subtitle: subtitles.join(' ')}
+    },
+  },
+})

--- a/site/app/meeting-minutes/[slug]/page.tsx
+++ b/site/app/meeting-minutes/[slug]/page.tsx
@@ -6,6 +6,8 @@ import {
 } from "@/lib/sanity/sanity.endpoints";
 import { StyledArticle } from "@/components/styled_article";
 import Main from "@/components/main";
+import { H3 } from "@/components/typography";
+import { Divider } from "@/components/divider";
 
 interface MeetingMinutesPageProps {
   params: {
@@ -55,11 +57,13 @@ export default async function MeetingMinutesPage({
           </div>
         </header>
 
+        <H3>Tastings</H3>
         {sharedTastings &&
           StyledText({
             value: sharedTastings,
           })}
-
+        <Divider></Divider>
+        <H3>Meeting Notes</H3>
         {meetingNotes &&
           StyledText({
             value: meetingNotes,

--- a/site/app/meeting-minutes/[slug]/page.tsx
+++ b/site/app/meeting-minutes/[slug]/page.tsx
@@ -1,0 +1,73 @@
+import { notFound } from "next/navigation";
+import StyledText from "@/components/styled_text";
+import {
+  getMeetingMinutesBySlug,
+  getMeetingMinutesSlugs,
+} from "@/lib/sanity/sanity.endpoints";
+import { StyledArticle } from "@/components/styled_article";
+import Main from "@/components/main";
+
+interface MeetingMinutesPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+/// This is the entrypoint for the dynamic route of [slug]
+/// NextJS provides the params object, which contains the slug
+export default async function MeetingMinutesPage({
+  params,
+}: MeetingMinutesPageProps) {
+  // Handle common user URL mistakes
+  const sanitizedSlug = params.slug
+    .replace(/\/+/g, "/")
+    .replace(/^\/|\/$/g, "");
+
+  const meetingMinutes = await getMeetingMinutesBySlug(sanitizedSlug);
+
+  if (!meetingMinutes) {
+    notFound();
+  }
+
+  const { sharedTastings, meetingNotes, title, author, meetingDate } =
+    meetingMinutes;
+
+  return (
+    <Main>
+      <StyledArticle>
+        <header className="mb-8 space-y-4">
+          <h1 className="m-0">{title}</h1>
+          <div className="flex items-center gap-x-4 text-sm not-prose text-muted-foreground">
+            {author?.name && <span>By {author.name}</span>}
+            {meetingDate && (
+              <>
+                <span>•</span>
+                <time dateTime={meetingDate}>
+                  {"Meeting notes for "}
+                  {new Date(meetingDate).toLocaleDateString("en-US", {
+                    month: "long",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                </time>{" "}
+              </>
+            )}
+          </div>
+        </header>
+
+        {sharedTastings &&
+          StyledText({
+            value: sharedTastings,
+          })}
+
+        {meetingNotes &&
+          StyledText({
+            value: meetingNotes,
+          })}
+      </StyledArticle>
+    </Main>
+  );
+}
+
+// The function should return an array of objects, where each object has a `slug` property.
+export const generateStaticParams = getMeetingMinutesSlugs;

--- a/site/app/meeting-minutes/page.tsx
+++ b/site/app/meeting-minutes/page.tsx
@@ -1,8 +1,10 @@
-import { ArchiveSection } from "@/components/archive_section";
-import { Divider } from "@/components/divider";
-import Main from "@/components/main";
-import { H1 } from "@/components/typography";
 import { Metadata } from "next";
+import { getMeetingMinutes } from "@/lib/sanity/sanity.endpoints";
+import { ArchiveSection } from "@/components/archive_section";
+import Main from "@/components/main";
+import { H1, H2 } from "@/components/typography";
+import { Card } from "@/components/card";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: {
@@ -12,9 +14,27 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
+  const meetingMinutes = await getMeetingMinutes();
   return (
     <Main>
-      <H1>Meeting Minutes</H1>
+      <div className="space-y-8 mb-8">
+        <H1>Meeting Minutes</H1>
+        <section id="meeting-minutes" className="flex flex-col gap-6">
+          {meetingMinutes.map((meetingMinutesInfo) => (
+            <Link
+              href={`/meeting-minutes/${meetingMinutesInfo.slug}`}
+              key={meetingMinutesInfo._id}
+            >
+              <Card
+                key={`${meetingMinutesInfo._id}_card`}
+                className="group relative overflow-hidden transition-colors hover:bg-slate-700 md:p-6"
+              >
+                <H2 className="border-b-0">{meetingMinutesInfo.title}</H2>
+              </Card>
+            </Link>
+          ))}
+        </section>
+      </div>
       <ArchiveSection
         archiveType="meeting minutes"
         url="https://docs.google.com/spreadsheets/d/1pUzcV2MVy1lp9vWkHeAFMb8aHY23q0AjYnTVvUl6Yuk/edit?usp=drive_link"

--- a/site/lib/sanity/sanity.endpoints.ts
+++ b/site/lib/sanity/sanity.endpoints.ts
@@ -16,6 +16,7 @@ import {
   eventsQuery,
   galleryImagesQuery,
   meetingMinutesBySlugQuery,
+  meetingMinutesQuery,
   membersQuery,
   postBySlugQuery,
   postSlugsQuery,
@@ -166,6 +167,18 @@ function getMeetingMinutesFromSanityMeetingMinutes(
         }
       : undefined,
   };
+}
+
+export async function getMeetingMinutes(): Promise<MeetingMinutes[]> {
+  const meetingMinutes = await clientFetch<SanityMeetingMinutes[]>({
+    query: meetingMinutesQuery,
+    tags: ["meetingMinutes"],
+  }).catch((err) => console.error(err));
+
+  const processedMeetingMinutes: MeetingMinutes[] | undefined =
+    meetingMinutes?.map(getMeetingMinutesFromSanityMeetingMinutes);
+
+  return processedMeetingMinutes || [];
 }
 
 interface Post extends Omit<SanityPost, "author" | "coverImage"> {

--- a/site/lib/sanity/sanity.queries.ts
+++ b/site/lib/sanity/sanity.queries.ts
@@ -16,6 +16,12 @@ const _postFields = groq`
   "author": author->{name, ${groqMetaAltImage("picture")},},
 `;
 
+const _meetingMinutesFields = groq`
+  ...,
+  "slug": slug.current,
+  "author": author->{name, ${groqMetaAltImage("picture")},},
+`;
+
 // End Fields
 
 // Queries
@@ -28,8 +34,15 @@ export const aboutQuery = groq`
 export const meetingMinutesQuery = groq`
 *[_type == "meetingMinutes"] | order(meetingDate desc, _updatedAt desc) {
   ...,
-  attendees[]->
 }`;
+
+export const meetingMinutesBySlugQuery = groq`
+*[_type == "meetingMinutes" && slug.current == $slug][0] {
+  ${_meetingMinutesFields}
+}`;
+
+export const meetingMinutesSlugsQuery = groq`
+*[_type == "meetingMinutes"]{"slug": slug.current}`;
 
 export const membersQuery = groq`
 *[_type == "member"] {

--- a/site/lib/sanity/sanity.queries.ts
+++ b/site/lib/sanity/sanity.queries.ts
@@ -19,7 +19,7 @@ const _postFields = groq`
 const _meetingMinutesFields = groq`
   ...,
   "slug": slug.current,
-  "author": author->{name, ${groqMetaAltImage("picture")},},
+  "author": author->{name, ${groqMetaAltImage("picture")},}
 `;
 
 // End Fields
@@ -33,7 +33,7 @@ export const aboutQuery = groq`
 
 export const meetingMinutesQuery = groq`
 *[_type == "meetingMinutes"] | order(meetingDate desc, _updatedAt desc) {
-  ...,
+  ${_meetingMinutesFields},
 }`;
 
 export const meetingMinutesBySlugQuery = groq`

--- a/site/lib/sanity/sanity.types.ts
+++ b/site/lib/sanity/sanity.types.ts
@@ -38,7 +38,7 @@ export interface SanityMeetingMinutes {
   meetingDate?: string;
   _updatedAt?: string;
   author?: SanityAuthor;
-  slug?: string;
+  slug: string;
   sharedTastings?: PortableTextBlock[];
   meetingNotes?: PortableTextBlock[];
 }

--- a/site/lib/sanity/sanity.types.ts
+++ b/site/lib/sanity/sanity.types.ts
@@ -32,6 +32,17 @@ export interface SanityPost {
   content?: PortableTextBlock[];
 }
 
+export interface SanityMeetingMinutes {
+  _id: string;
+  title?: string;
+  meetingDate?: string;
+  _updatedAt?: string;
+  author?: SanityAuthor;
+  slug?: string;
+  sharedTastings?: PortableTextBlock[];
+  meetingNotes?: PortableTextBlock[];
+}
+
 export interface SanityEvent {
   _id: string;
   _type: string;


### PR DESCRIPTION
- Add meeting minutes schema to cms
- Add a display for the list of all meeting minutes from cms as links on the main meeting minutes page
- Add a page to display meeting minutes details

_Note: Images can be added to meeting minutes in CMS, but are currently not displayed on site_


<img src="https://media1.giphy.com/media/hqqu3NvxUJ07boRjqP/giphy.gif"/>